### PR TITLE
Send pushes to channels

### DIFF
--- a/pushbullet/channel.py
+++ b/pushbullet/channel.py
@@ -1,0 +1,37 @@
+class Channel(object):
+
+    def __init__(self, account, channel_info):
+        self._account = account
+        self.channel_tag = channel_info.get("tag")
+
+        for attr in ("name", "description", "created", "modified"):
+                setattr(self, attr, channel_info.get(attr))
+
+    def push_note(self, title, body):
+        data = {"type": "note", "title": title, "body": body}
+        return self._push(data)
+
+    def push_address(self, name, address):
+        data = {"type": "address", "name": name, "address": address}
+        return self._push(data)
+
+    def push_list(self, title, items):
+        data = {"type": "list", "title": title, "items": items}
+        return self._push(data)
+
+    def push_link(self, title, url, body=None):
+        data = {"type": "link", "title": title, "url": url, "body": body}
+        return self._push(data)
+
+    def push_file(self, file_name, file_url, file_type, body=None):
+        return self._account.push_file(file_name, file_url, file_type, body, device=self)
+
+    def _push(self, data):
+        data["channel_tag"] = self.channel_tag
+        return self._account._push(data)
+
+    def __str__(self):
+        return "Channel(name: '{}' tag: '{}')".format(self.name, self.channel_tag)
+
+    def __repr__(self):
+        return self.__str__()

--- a/pushbullet/channel.py
+++ b/pushbullet/channel.py
@@ -24,7 +24,7 @@ class Channel(object):
         return self._push(data)
 
     def push_file(self, file_name, file_url, file_type, body=None):
-        return self._account.push_file(file_name, file_url, file_type, body, device=self)
+        return self._account.push_file(file_name, file_url, file_type, body, channel=self)
 
     def _push(self, data):
         data["channel_tag"] = self.channel_tag

--- a/pushbullet/invalid_key_error.py
+++ b/pushbullet/invalid_key_error.py
@@ -1,0 +1,6 @@
+class InvalidKeyError(Exception):
+    def __init__(self):
+        self.value = "Invalid API Key"
+
+    def __str__(self):
+        return repr(self.value)

--- a/pushbullet/pushbullet.py
+++ b/pushbullet/pushbullet.py
@@ -4,6 +4,7 @@ import requests
 
 
 from .device import Device
+from .channel import Channel
 from .contact import Contact
 from .filetype import get_file_type
 
@@ -13,6 +14,7 @@ class PushBullet(object):
 
     DEVICES_URL = "https://api.pushbullet.com/v2/devices"
     CONTACTS_URL = "https://api.pushbullet.com/v2/contacts"
+    CHANNELS_URL = "https://api.pushbullet.com/v2/channels"
     ME_URL = "https://api.pushbullet.com/v2/users/me"
     PUSH_URL = "https://api.pushbullet.com/v2/pushes"
     UPLOAD_REQUEST_URL = "https://api.pushbullet.com/v2/upload-request"
@@ -56,6 +58,17 @@ class PushBullet(object):
             self.user_info = r.json()
         else:
             self.user_info = {}
+
+    def _load_channels(self):
+        self.channels = []
+
+        resp = self._session.get(self.CHANNELS_URL)
+        resp_dict = resp.json()
+        channel_list = resp_dict.get("channels", [])
+
+        for channel_info in channel_list:
+            c = Channel(self, channel_info)
+            self.channels.append(c)
 
     @staticmethod
     def _recipient(device=None, contact=None, email=None):
@@ -235,3 +248,4 @@ class PushBullet(object):
         self._load_devices()
         self._load_contacts()
         self._load_user_info()
+        self._load_channels()

--- a/pushbullet/pushbullet.py
+++ b/pushbullet/pushbullet.py
@@ -71,7 +71,7 @@ class PushBullet(object):
             self.channels.append(c)
 
     @staticmethod
-    def _recipient(device=None, contact=None, email=None):
+    def _recipient(device=None, contact=None, email=None, channel=None):
         data = dict()
 
         if device:
@@ -80,6 +80,8 @@ class PushBullet(object):
             data["email"] = contact.email
         elif email:
             data["email"] = email
+        elif channel:
+            data["channel_tag"] = channel.channel_tag
 
         return data
 
@@ -199,12 +201,12 @@ class PushBullet(object):
 
         return True, {"file_type": file_type, "file_url": file_url, "file_name": file_name}
 
-    def push_file(self, file_name, file_url, file_type, body=None, device=None, contact=None, email=None):
+    def push_file(self, file_name, file_url, file_type, body=None, device=None, contact=None, email=None, channel=None):
         data = {"type": "file", "file_type": file_type, "file_url": file_url, "file_name": file_name}
         if body:
             data["body"] = body
 
-        data.update(PushBullet._recipient(device, contact, email))
+        data.update(PushBullet._recipient(device, contact, email, channel))
     
         return self._push(data)
     

--- a/readme.rst
+++ b/readme.rst
@@ -179,6 +179,31 @@ Of course, you can also delete devices, even those not added by you.
     success, error_message = pb.remove_device(listener)
 
 
+Channels
+~~~~~~~~~~~~
+
+You can also send pushes to channels. First, create a channel on the PushBullet
+website (also make sure to subscribe to that channel). All channels which
+belong to the current user can be retrieved as follows:
+
+.. code:: python
+    
+    # Get all channels created by the current user
+    print(pb.channels)
+    # [Channel('My Channel' 'channel_identifier')]
+
+    my_channel = pb.channels[0]
+
+Then you can send a push to all subscribers of this channel like so:
+
+.. code:: python
+    
+    success, push = my_channel.push_note("Hello Channel!", "Hello My Channel")
+
+Note that you can only push to channels which have been created by the current
+user.
+
+
 Contacts
 ~~~~~~~~~~~~
 


### PR DESCRIPTION
Added additional class `Channel`, which enables sending push messages to channels created by the current user. The channels which have been created are accessible through a new attribute `channels` of the `PushBullet` class. The API of the new `Channel` class is identical to existing classes (such as `Device`). I've updated the Readme with an example.