### PR TITLE
Correct typo for push_note() example in readme

### DIFF
--- a/readme.rst
+++ b/readme.rst
@@ -69,7 +69,7 @@ Pushing a text note
 
 .. code:: python
 
-    push = pb.push_note("This is the title", "This is the body".)
+    push = pb.push_note("This is the title", "This is the body")
 
 ``push`` is a dictionary containing the data returned by the Pushbullet API.
 


### PR DESCRIPTION
Under "Pushing a text note", the pb.push_note() example has a trailing fullstop outside the inverted commas which is obviously invalid syntax.