### PR TITLE
Fix 403 response codes

### DIFF
--- a/pushbullet/pushbullet.py
+++ b/pushbullet/pushbullet.py
@@ -31,7 +31,7 @@ class Pushbullet(object):
     def _get_data(self, url):
         resp = self._session.get(url)
 
-        if resp.status_code == 401:
+        if resp.status_code != requests.codes.ok:
             raise InvalidKeyError()
 
         return resp.json()


### PR DESCRIPTION
A bad response isn't necessarily a 401 response, use the requests library response check instead of hardcoding 401 to cover these issues.