### PR TITLE
Fix libmagic issue with Python 3

### DIFF
--- a/pushbullet/filetype.py
+++ b/pushbullet/filetype.py
@@ -1,7 +1,7 @@
 def _magic_get_file_type(f, _):
     file_type = magic.from_buffer(f.read(1024), mime=True)
     f.seek(0)
-    return file_type
+    return file_type.decode("ASCII")
 
 
 def _guess_file_type(_, filename):


### PR DESCRIPTION
For some reason libmagic return bytes instead of a string in Python 3, which can't be serialised to json