### PR TITLE
Fix: Do not use the non-public parse_requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,9 @@
-requests>=1.0.0
-python-magic
-websocket-client
+###
+# This file is only here to make sure that something like
+#
+#    pip install -e .
+#
+# works as expected. Requirements can be found in setup.py.
+###
+
+.

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,7 @@
 import os
-import uuid
 import sys
 
 from setuptools import setup
-from pip.req import parse_requirements
 
 with open("./pushbullet/__version__.py") as version_file:
     version = version_file.read().split("\"")[1]
@@ -12,8 +10,11 @@ if sys.argv[-1] == 'publish':
     os.system('python setup.py sdist upload')
     sys.exit()
 
-install_reqs = parse_requirements("requirements.txt",  session=uuid.uuid1())
-
+install_reqs = [
+    "requests>=1.0.0",
+    "python-magic",
+    "websocket-client"
+]
 
 
 def read(fname):
@@ -47,5 +48,5 @@ setup(
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Topic :: Utilities"
     ],
-    install_requires=[str(ir.req) for ir in install_reqs]
+    install_requires=install_reqs
 )


### PR DESCRIPTION
pip.req.parse_requirements is not considered part of the public
pip API by the pip developers and hence should never be used
as such. Its signature can change at any given moment, making
installations depending on it just break.

This patch moves the actual requirement specification over into
setup.py and modifies requirements.txt to only contain a reference
to the local package, in compliance with the suggested usage
pattern for setup.py vs requirements.txt.

See also:
  * http://stackoverflow.com/a/22649833/2028598
  * https://caremad.io/2013/07/setup-vs-requirement/

Solves #36