### PR TITLE
Fixes for mirror_example

### DIFF
--- a/example/mirror_example.py
+++ b/example/mirror_example.py
@@ -7,12 +7,13 @@ import hashlib
 import base64
 import subprocess
 import os, sys
+import time
 
 from pushbullet import PushBullet, Listener
 
 class Mirrorer(object):
 
-    def __init__(self, auth_key, temp_folder, device_name, last_push = 0, device_iden=None):
+    def __init__(self, auth_key, temp_folder, device_name, last_push = time.time(), device_iden=None):
         self.temp_folder = temp_folder
         if not os.path.exists(self.temp_folder):
             os.makedirs(temp_folder)

--- a/example/mirror_example.py
+++ b/example/mirror_example.py
@@ -53,16 +53,15 @@ class Mirrorer(object):
             return path
 
     def check_pushes(self):
-        success, pushes = self.pb.get_pushes(self.last_push)
-        if success:
-            for push in pushes:
-                if not isinstance(push,dict): 
-                    # not a push object
-                    continue
-                if ((push.get("target_device_iden", self.device.device_iden) == self.device.device_iden) and not (push.get("dismissed", True))):
-                    self.notify(push.get("title", ""), push.get("body", ""))
-                    self.pb.dismiss_push(push.get("iden"))
-                self.last_push = max(self.last_push, push.get("created"))
+        pushes = self.pb.get_pushes(self.last_push)
+        for push in pushes:
+            if not isinstance(push,dict): 
+                # not a push object
+                continue
+            if ((push.get("target_device_iden", self.device.device_iden) == self.device.device_iden) and not (push.get("dismissed", True))):
+                self.notify(push.get("title", ""), push.get("body", ""))
+                self.pb.dismiss_push(push.get("iden"))
+            self.last_push = max(self.last_push, push.get("created"))
 
     def watcher(self, push):
         if push["type"] == "push" and push["push"]["type"] == "mirror":

--- a/example/sample_config.json
+++ b/example/sample_config.json
@@ -1,5 +1,5 @@
 {
 	"temp_folder": "./tempdir",
-	"auth_key": "YOURKEYHERE"
+	"auth_key": "YOURKEYHERE",
 	"device_name": "Ubuntu"
 }


### PR DESCRIPTION
There were a few problems with the mirror example

1. Creating a device with call to PushBullet.new_device() does not return a (boolean,device) tuple. It will throw and error if it fails. Using a try catch with informative error messages should help the user. Re-raising the error will also stop the program, since it should not run without a valid device.

2. The default "last_push" is 0. On an account with many pushes, this could cause a rate limit restriction from pushbullet.com just by running the mirror a few times. setting it to time.time() will restrict mirror to new pushes.

3. In check_pushes() there are some errors when the push in pushes is not actually a push dictionary. Adding a check for isinstance(push,dict) will prevent this error.

4. dump_config does not write out the nickname. This removes the device_name field from the initial config file. Added device_name=self.device.nickname to the output.

5. Bug in main. the mirror object was referred to as self. Fixed.