### PR TITLE
Fix edit_device method to keep nickname

### DIFF
--- a/pushbullet/pushbullet.py
+++ b/pushbullet/pushbullet.py
@@ -108,7 +108,7 @@ class Pushbullet(object):
             raise PushbulletError(r.text)
 
     def edit_device(self, device, nickname=None, model=None, manufacturer=None):
-        data = {"nickname": nickname}
+        data = {"nickname": nickname or device.nickname}
         iden = device.device_iden
         r = self._session.post("{}/{}".format(self.DEVICES_URL, iden), data=json.dumps(data))
         if r.status_code == requests.codes.ok:


### PR DESCRIPTION
Editing a device using the `edit_device()` method without a nickname given would result in the nickname being deleted from the device. This is due to the default `nickname=None` value. This also then causes a 'tuple index out of range' error if the device list is called upon using `pb.devices`.