### PR TITLE
Hotfix/edit device with manufacturer and model

### DIFF
--- a/pushbullet/pushbullet.py
+++ b/pushbullet/pushbullet.py
@@ -108,9 +108,8 @@ class Pushbullet(object):
             raise PushbulletError(r.text)
 
     def edit_device(self, device, nickname=None, model=None, manufacturer=None):
-        data = {k: v for k, v in
-                (("nickname", nickname or device.nickname), ("model", model),
-                 ("manufacturer", manufacturer)) if v is not None}
+        data = dict((k, v) for k, v in 
+                    (("nickname", nickname or device.nickname), ("model", model), ("manufacturer", manufacturer)) if v is not None)
         iden = device.device_iden
         r = self._session.post("{}/{}".format(self.DEVICES_URL, iden), data=json.dumps(data))
         if r.status_code == requests.codes.ok:

--- a/pushbullet/pushbullet.py
+++ b/pushbullet/pushbullet.py
@@ -108,7 +108,9 @@ class Pushbullet(object):
             raise PushbulletError(r.text)
 
     def edit_device(self, device, nickname=None, model=None, manufacturer=None):
-        data = {"nickname": nickname or device.nickname}
+        data = {k: v for k, v in
+                (("nickname", nickname or device.nickname), ("model", model),
+                 ("manufacturer", manufacturer)) if v is not None}
         iden = device.device_iden
         r = self._session.post("{}/{}".format(self.DEVICES_URL, iden), data=json.dumps(data))
         if r.status_code == requests.codes.ok:

--- a/readme.rst
+++ b/readme.rst
@@ -192,7 +192,7 @@ You can change the nickname, the manufacturer and the model of the device:
 
 .. code:: python
 
-    listener = pb.edit_device(listener, make="Python", model="3.4.1")
+    listener = pb.edit_device(listener, manufacturer="Python", model="3.4.1")
     motog = pb.edit_device(motog, nickname="My MotoG")
 
 


### PR DESCRIPTION
Fix two issues when using `edit_device()`:
- Fix edit_devices() to save new options in README
- Fix typo in readme for editing devices make/manufacturer