### PR TITLE
Add new method to get device by nickname

### DIFF
--- a/pushbullet/pushbullet.py
+++ b/pushbullet/pushbullet.py
@@ -150,6 +150,14 @@ class Pushbullet(object):
         else:
             raise PushbulletError(r.text)
 
+    def get_device(self, nickname):
+        req_device = next((device for device in self.devices if device.nickname == nickname), None)
+        
+        if req_device is None:
+            raise InvalidKeyError()
+        
+        return req_device
+    
     def get_pushes(self, modified_after=None, limit=None, filter_inactive=True):
         data = {"modified_after": modified_after, "limit": limit}
         if filter_inactive:


### PR DESCRIPTION
Currently to retrieve a specific device, the user needs to know the index of the `Device` in the device list. This requires either to print devices first using `pb.devices` or to retrieve all devices and use a loop.

As the pushbullet.py package retrieves all devices on initial connection, it is easier to provide a helper method for the end user.