### PR TITLE
Edited Device attributes and adjusted new_device() function

### DIFF
--- a/pushbullet/device.py
+++ b/pushbullet/device.py
@@ -9,9 +9,9 @@ class Device(object):
         self._account = account
         self.device_iden = device_info.get("iden")
 
-        for attr in ("push_token", "app_version", "android_sdk_version", "fingerprint",
-                     "active", "nickname", "manufacturer", "type", "created", "modified",
-                     "android_version", "model", "pushable"):
+        for attr in ("push_token", "app_version", "fingerprint", "created", "modified",
+                    "active", "nickname", "generated_nickname", "manufacturer", "icon",
+                    "model", "has_sms", "key_fingerprint"):
             setattr(self, attr, device_info.get(attr))
 
     def push_note(self, title, body):

--- a/pushbullet/pushbullet.py
+++ b/pushbullet/pushbullet.py
@@ -87,8 +87,10 @@ class Pushbullet(object):
 
         return data
 
-    def new_device(self, nickname):
-        data = {"nickname": nickname, "type": "stream"}
+    def new_device(self, nickname, manufacturer=None, model=None, icon="system"):
+        data = {"nickname": nickname, "icon": icon}
+        data.update({k: v for k, v in
+            (("model", model), ("manufacturer", manufacturer)) if v is not None})
         r = self._session.post(self.DEVICES_URL, data=json.dumps(data))
         if r.status_code == requests.codes.ok:
             new_device = Device(self, r.json())

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -11,7 +11,8 @@ class TestDevices(object):
     def setup_class(cls):
         cls.device_iden = "test_iden"
         device_info = {"active": True, "iden": cls.device_iden, "created": time.time(), "modified": time.time(),
-                       "type": "stream", "kind": "stream", "nickname": "test dev", "manufacturer": "test c", "model": "test m", "pushable": True}
+                       "icon": "system", "generated_nickname": False, "nickname": "test dev", "manufacturer": "test c",
+                       "model": "test m", "has_sms": False}
         cls.account = mock.Mock(return_value=True)
         cls.device = device.Device(cls.account, device_info)
 


### PR DESCRIPTION
The attributes on the `Device` were from an old version of the pushbullet API. Deprecated attributes have been removed and latest ones have been added.

The `new_device()` function has been updated to support some of these new attributes on device creation.