### PR TITLE
Add new function to get_channel and ability to push direct to channel

### DIFF
--- a/pushbullet/pushbullet.py
+++ b/pushbullet/pushbullet.py
@@ -161,6 +161,14 @@ class Pushbullet(object):
 
         return req_device
 
+    def get_channel(self, channel_tag):
+        req_channel = next((channel for channel in self.channels if channel.channel_tag == channel_tag), None)
+
+        if req_channel is None:
+            raise InvalidKeyError()
+
+        return req_channel
+
     def get_pushes(self, modified_after=None, limit=None, filter_inactive=True):
         data = {"modified_after": modified_after, "limit": limit}
         if filter_inactive:
@@ -232,10 +240,10 @@ class Pushbullet(object):
 
         return self._push(data)
 
-    def push_note(self, title, body, device=None, chat=None, email=None):
+    def push_note(self, title, body, device=None, chat=None, email=None, channel=None):
         data = {"type": "note", "title": title, "body": body}
 
-        data.update(Pushbullet._recipient(device, chat, email))
+        data.update(Pushbullet._recipient(device, chat, email, channel))
 
         return self._push(data)
 
@@ -253,10 +261,10 @@ class Pushbullet(object):
 
         return self._push(data)
 
-    def push_link(self, title, url, body=None, device=None, chat=None, email=None):
+    def push_link(self, title, url, body=None, device=None, chat=None, email=None, channel=None):
         data = {"type": "link", "title": title, "url": url, "body": body}
 
-        data.update(Pushbullet._recipient(device, chat, email))
+        data.update(Pushbullet._recipient(device, chat, email, channel))
 
         return self._push(data)
 

--- a/pushbullet/pushbullet.py
+++ b/pushbullet/pushbullet.py
@@ -157,7 +157,7 @@ class Pushbullet(object):
         req_device = next((device for device in self.devices if device.nickname == nickname), None)
 
         if req_device is None:
-            raise InvalidKeyError()
+            raise PushbulletError('No device found with nickname "{}"'.format(nickname))
 
         return req_device
 
@@ -165,7 +165,7 @@ class Pushbullet(object):
         req_channel = next((channel for channel in self.channels if channel.channel_tag == channel_tag), None)
 
         if req_channel is None:
-            raise InvalidKeyError()
+            raise PushbulletError('No channel found with channel_tag "{}"'.format(channel_tag))
 
         return req_channel
 

--- a/readme.rst
+++ b/readme.rst
@@ -229,11 +229,20 @@ belong to the current user can be retrieved as follows:
 
     my_channel = pb.channels[0]
 
+    # Or retrieve a channel by its channel_tag. Note that an InvalidKeyError is raised if the channel_tag does not exist
+    my_channel = pb.get_channel('My Channel')
+
 Then you can send a push to all subscribers of this channel like so:
 
 .. code:: python
 
     push = my_channel.push_note("Hello Channel!", "Hello My Channel")
+
+Alternatively we can pass the channel to push methods:
+
+.. code:: python
+
+    push = pb.push_note("Hello Channel!", "Hello My Channel.", channel=my_channel)
 
 Note that you can only push to channels which have been created by the current
 user.


### PR DESCRIPTION
As per issue #34 - Pushbullet allows pushing direct to a channel. I have added a shortcut method to retrieve channel by channel_tag which can be used as a shortcut in `pb.push_note(channel=pb.get_channel())` if need be.

Edited readme as well to describe the new functions.