### PR TITLE
Add decryption support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
 install:
 - pip install .
 - pip install coveralls
+- pip install cryptography
 script: coverage run --source pushbullet -m py.test
 env:
 - PUSHBULLET_API_KEY=RrFnc1xaeQXnRrr2auoGA1e8pQ8MWmMF

--- a/pushbullet/listener.py
+++ b/pushbullet/listener.py
@@ -17,6 +17,7 @@ WEBSOCKET_URL = 'wss://stream.pushbullet.com/websocket/'
 class Listener(Thread, websocket.WebSocketApp):
     def __init__(self, account,
                  on_push=None,
+                 on_error=None,
                  http_proxy_host=None,
                  http_proxy_port=None):
         """
@@ -31,6 +32,7 @@ class Listener(Thread, websocket.WebSocketApp):
         Thread.__init__(self)
         websocket.WebSocketApp.__init__(self, WEBSOCKET_URL + self._api_key,
                                         on_open=self.on_open,
+                                        on_error=on_error,
                                         on_message=self.on_message,
                                         on_close=self.on_close)
 

--- a/pushbullet/pushbullet.py
+++ b/pushbullet/pushbullet.py
@@ -343,6 +343,34 @@ class Pushbullet(object):
         ciphertext = b"1" + encryptor.tag + iv + ciphertext
         return standard_b64encode(ciphertext).decode("ASCII")
 
+    def _decrypt_data(self, data):
+        assert self._encryption_key
+
+        from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+        from cryptography.hazmat.backends import default_backend
+        from binascii import a2b_base64
+
+        key = self._encryption_key
+        encoded_message = a2b_base64(data)
+
+        version = encoded_message[0:1]
+        tag = encoded_message[1:17]
+        initialization_vector = encoded_message[17:29]
+        encrypted_message = encoded_message[29:]
+
+        if version != b"1":
+            raise Exception("Invalid Version")
+
+        cipher = Cipher(algorithms.AES(key),
+                        modes.GCM(initialization_vector, tag),
+                        backend=default_backend())
+        decryptor = cipher.decryptor()
+
+        decrypted = decryptor.update(encrypted_message) + decryptor.finalize()
+        decrypted = decrypted.decode()
+
+        return(decrypted)
+
     def refresh(self):
         self._load_devices()
         self._load_chats()

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1,0 +1,16 @@
+import os
+
+import pytest
+import pushbullet
+from binascii import a2b_base64
+
+API_KEY = os.environ["PUSHBULLET_API_KEY"]
+
+def test_decryption():
+    pb = pushbullet.Pushbullet(API_KEY, encryption_password="hunter2")
+    pb._encryption_key = a2b_base64("1sW28zp7CWv5TtGjlQpDHHG4Cbr9v36fG5o4f74LsKg=")
+
+    test_data = "MSfJxxY5YdjttlfUkCaKA57qU9SuCN8+ZhYg/xieI+lDnQ=="
+    decrypted = pb._decrypt_data(test_data)
+
+    assert decrypted == "meow!"


### PR DESCRIPTION
This pull request adds to the previous commits on decryption. It currently implements a method, `self._decrypt_data(self, data)` which returns the decrypted `data`. It is based on both the `Criptography` documentation and the Pushbullet API example on E2E crypto.

Here's a screencast showing it in action:

![Screencast](https://gfycat.com/SoreFrigidCaracal)