### PR TITLE
Add title parameter for send_file in device and channel objects. Improves #52

### DIFF
--- a/pushbullet/channel.py
+++ b/pushbullet/channel.py
@@ -30,8 +30,8 @@ class Channel(object):
         data = {"type": "link", "title": title, "url": url, "body": body}
         return self._push(data)
 
-    def push_file(self, file_name, file_url, file_type, body=None):
-        return self._account.push_file(file_name, file_url, file_type, body, channel=self)
+    def push_file(self, file_name, file_url, file_type, body=None, title=None):
+        return self._account.push_file(file_name, file_url, file_type, body=body, title=title, channel=self)
 
     def _push(self, data):
         data["channel_tag"] = self.channel_tag

--- a/pushbullet/device.py
+++ b/pushbullet/device.py
@@ -32,8 +32,8 @@ class Device(object):
         data = {"type": "link", "title": title, "url": url, "body": body}
         return self._push(data)
 
-    def push_file(self, file_name, file_url, file_type, body=None):
-        return self._account.push_file(file_name, file_url, file_type, body, device=self)
+    def push_file(self, file_name, file_url, file_type, body=None, title=None):
+        return self._account.push_file(file_name, file_url, file_type, body=body, title=title, device=self)
 
     def _push(self, data):
         data["device_iden"] = self.device_iden

--- a/pushbullet/pushbullet.py
+++ b/pushbullet/pushbullet.py
@@ -255,7 +255,7 @@ class Pushbullet(object):
 
         return {"file_type": file_type, "file_url": file_url, "file_name": file_name}
 
-    def push_file(self, file_name, file_url, file_type, body=None, device=None, chat=None, email=None, channel=None, title=None):
+    def push_file(self, file_name, file_url, file_type, body=None, title=None, device=None, chat=None, email=None, channel=None):
         data = {"type": "file", "file_type": file_type, "file_url": file_url, "file_name": file_name}
         if body:
             data["body"] = body

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -57,8 +57,9 @@ class TestChannels(object):
         file_url = "http://file.url"
         file_type = "test/type"
         body = "test body"
-        self.channel.push_file(file_name, file_url, file_type, body)
-        self.account.push_file.assert_called_with(file_name, file_url, file_type, body, channel=self.channel)
+        title = "test title"
+        self.channel.push_file(file_name, file_url, file_type, body=body, title=title)
+        self.account.push_file.assert_called_with(file_name, file_url, file_type, body=body, title=title, channel=self.channel)
 
     def test_push(self):
         data = {"title": "test title"}

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -58,8 +58,9 @@ class TestDevices(object):
         file_url = "http://file.url"
         file_type = "test/type"
         body = "test body"
-        self.device.push_file(file_name, file_url, file_type, body)
-        self.account.push_file.assert_called_with(file_name, file_url, file_type, body, device=self.device)
+        title = "test title"
+        self.device.push_file(file_name, file_url, file_type, body=body, title=title)
+        self.account.push_file.assert_called_with(file_name, file_url, file_type, title=title, body=body, device=self.device)
 
     def test_push(self):
         data = {"title": "test title"}


### PR DESCRIPTION
#52 added the title parameter to `pushbullet.py`, but the channel and device objects didn't have this parameter in `send_file`.