### PR TITLE
Include tests and examples in source distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,7 @@
 include LICENSE
 include readme.rst
 include requirements.txt
+graft tests
+graft example
+global-exclude __pycache__
+global-exclude *.py[co]


### PR DESCRIPTION
Hi,
It would be really nice if you could include tests and examples in the PyPI tarballs as we at Gentoo usually get the package source there.