### PR TITLE
Better handling for python3 missing `decode`

### DIFF
--- a/pushbullet/filetype.py
+++ b/pushbullet/filetype.py
@@ -11,10 +11,11 @@ def _guess_file_type(_, filename):
 # return str on python3.  Don't want to unconditionally
 # decode because that results in unicode on python2
 def maybe_decode(s):
-    if str == bytes:
-        return s.decode('utf-8')
-    else:
-        return s
+    try:
+        decoded = s.decode('utf-8')
+    except AttributeError as e:
+        decoded = s
+    return decoded
 
 
 try:


### PR DESCRIPTION
Got here from pushbullet-cli. We are having problems with the current approach. I managed to make it work by catching the possible exception