### PR TITLE
Fixed missing 1 required positional argument: 'ws'

### DIFF
--- a/pushbullet/listener.py
+++ b/pushbullet/listener.py
@@ -59,15 +59,15 @@ class Listener(Thread, websocket.WebSocketApp):
     def clean_history(self):
         self.history = []
 
-    def on_open(self, ws):
+    def on_open(self):
         self.connected = True
         self.last_update = time.time()
 
-    def on_close(self, ws):
+    def on_close(self):
         log.debug('Listener closed')
         self.connected = False
 
-    def on_message(self, ws, message):
+    def on_message(self, message):
         log.debug('Message received:' + message)
         try:
             json_message = json.loads(message)

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ if sys.argv[-1] == 'publish':
 install_reqs = [
     "requests>=1.0.0",
     "python-magic",
-    "websocket-client>=0.42.1"
+    "websocket-client>=0.53.0"
 ]
 
 


### PR DESCRIPTION
As of version 0.53.0 of websocket-client (websocket-client/websocket-client@efcf31b), the `ws` parameter is no longer needed.